### PR TITLE
Standard library header include fixes

### DIFF
--- a/include/ByteTrack/BYTETracker.h
+++ b/include/ByteTrack/BYTETracker.h
@@ -55,7 +55,7 @@ private:
                      std::vector<int> &rowsol,
                      std::vector<int> &colsol,
                      bool extend_cost = false,
-                     float cost_limit = LONG_MAX,
+                     float cost_limit = std::numeric_limits<float>::max(),
                      bool return_cost = true) const;
 
 private:

--- a/include/ByteTrack/BYTETracker.h
+++ b/include/ByteTrack/BYTETracker.h
@@ -5,6 +5,7 @@
 #include "ByteTrack/Object.h"
 
 #include <cstddef>
+#include <limits>
 #include <map>
 #include <memory>
 #include <vector>

--- a/include/ByteTrack/BYTETracker.h
+++ b/include/ByteTrack/BYTETracker.h
@@ -4,6 +4,7 @@
 #include "ByteTrack/lapjv.h"
 #include "ByteTrack/Object.h"
 
+#include <cstddef>
 #include <map>
 #include <memory>
 #include <vector>

--- a/include/ByteTrack/BYTETracker.h
+++ b/include/ByteTrack/BYTETracker.h
@@ -1,11 +1,12 @@
 #pragma once
 
+#include "ByteTrack/STrack.h"
+#include "ByteTrack/lapjv.h"
+#include "ByteTrack/Object.h"
+
 #include <map>
 #include <memory>
-
-#include <ByteTrack/STrack.h>
-#include <ByteTrack/lapjv.h>
-#include <ByteTrack/Object.h>
+#include <vector>
 
 namespace byte_track
 {

--- a/include/ByteTrack/KalmanFilter.h
+++ b/include/ByteTrack/KalmanFilter.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <Eigen/Dense>
+#include "Eigen/Dense"
 
-#include <ByteTrack/Rect.h>
+#include "ByteTrack/Rect.h"
 
 namespace byte_track
 {

--- a/include/ByteTrack/Object.h
+++ b/include/ByteTrack/Object.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <ByteTrack/Rect.h>
+#include "ByteTrack/Rect.h"
 
 namespace byte_track
 {

--- a/include/ByteTrack/Rect.h
+++ b/include/ByteTrack/Rect.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Eigen/Dense>
+#include "Eigen/Dense"
 
 namespace byte_track
 {

--- a/include/ByteTrack/STrack.h
+++ b/include/ByteTrack/STrack.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <ByteTrack/Rect.h>
-#include <ByteTrack/KalmanFilter.h>
+#include "ByteTrack/Rect.h"
+#include "ByteTrack/KalmanFilter.h"
 
 namespace byte_track
 {

--- a/include/ByteTrack/STrack.h
+++ b/include/ByteTrack/STrack.h
@@ -3,6 +3,8 @@
 #include "ByteTrack/Rect.h"
 #include "ByteTrack/KalmanFilter.h"
 
+#include <cstddef>
+
 namespace byte_track
 {
 enum class STrackState {

--- a/include/ByteTrack/lapjv.h
+++ b/include/ByteTrack/lapjv.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstddef>
+
 namespace byte_track
 {
 int lapjv_internal(const size_t n, double *cost[], int *x, int *y);

--- a/include/ByteTrack/lapjv.h
+++ b/include/ByteTrack/lapjv.h
@@ -1,11 +1,5 @@
 #pragma once
 
-#include <cstdio>
-#include <cstdlib>
-#include <cstring>
-
-#include <iostream>
-
 namespace byte_track
 {
 int lapjv_internal(const size_t n, double *cost[], int *x, int *y);

--- a/src/BYTETracker.cpp
+++ b/src/BYTETracker.cpp
@@ -1,4 +1,10 @@
-#include <ByteTrack/BYTETracker.h>
+#include "ByteTrack/BYTETracker.h"
+
+#include <map>
+#include <memory>
+#include <stdexcept>
+#include <utility>
+#include <vector>
 
 byte_track::BYTETracker::BYTETracker(const int& frame_rate,
                                      const int& track_buffer,

--- a/src/BYTETracker.cpp
+++ b/src/BYTETracker.cpp
@@ -457,14 +457,14 @@ double byte_track::BYTETracker::execLapjv(const std::vector<std::vector<float>> 
         }
     }
 
-    if (extend_cost || cost_limit < LONG_MAX)
+    if (extend_cost || cost_limit < std::numeric_limits<float>::max())
     {
         n = n_rows + n_cols;
         cost_c_extended.resize(n);
         for (size_t i = 0; i < cost_c_extended.size(); i++)
             cost_c_extended[i].resize(n);
 
-        if (cost_limit < LONG_MAX)
+        if (cost_limit < std::numeric_limits<float>::max())
         {
             for (size_t i = 0; i < cost_c_extended.size(); i++)
             {

--- a/src/BYTETracker.cpp
+++ b/src/BYTETracker.cpp
@@ -1,6 +1,7 @@
 #include "ByteTrack/BYTETracker.h"
 
 #include <cstddef>
+#include <limits>
 #include <map>
 #include <memory>
 #include <stdexcept>

--- a/src/BYTETracker.cpp
+++ b/src/BYTETracker.cpp
@@ -1,5 +1,6 @@
 #include "ByteTrack/BYTETracker.h"
 
+#include <cstddef>
 #include <map>
 #include <memory>
 #include <stdexcept>

--- a/src/KalmanFilter.cpp
+++ b/src/KalmanFilter.cpp
@@ -1,4 +1,4 @@
-#include <ByteTrack/KalmanFilter.h>
+#include "ByteTrack/KalmanFilter.h"
 
 byte_track::KalmanFilter::KalmanFilter(const float& std_weight_position,
                                        const float& std_weight_velocity) :

--- a/src/KalmanFilter.cpp
+++ b/src/KalmanFilter.cpp
@@ -1,5 +1,7 @@
 #include "ByteTrack/KalmanFilter.h"
 
+#include <cstddef>
+
 byte_track::KalmanFilter::KalmanFilter(const float& std_weight_position,
                                        const float& std_weight_velocity) :
     std_weight_position_(std_weight_position),

--- a/src/Object.cpp
+++ b/src/Object.cpp
@@ -1,4 +1,4 @@
-#include <ByteTrack/Object.h>
+#include "ByteTrack/Object.h"
 
 byte_track::Object::Object(const Rect<float> &_rect,
                            const int &_label,

--- a/src/Rect.cpp
+++ b/src/Rect.cpp
@@ -1,4 +1,6 @@
-#include <ByteTrack/Rect.h>
+#include "ByteTrack/Rect.h"
+
+#include <algorithm>
 
 template <typename T>
 byte_track::Rect<T>::Rect(const T &x, const T &y, const T &width, const T &height) :

--- a/src/STrack.cpp
+++ b/src/STrack.cpp
@@ -1,5 +1,7 @@
 #include "ByteTrack/STrack.h"
 
+#include <cstddef>
+
 byte_track::STrack::STrack(const Rect<float>& rect, const float& score) :
     kalman_filter_(),
     mean_(),

--- a/src/STrack.cpp
+++ b/src/STrack.cpp
@@ -1,4 +1,4 @@
-#include <ByteTrack/STrack.h>
+#include "ByteTrack/STrack.h"
 
 byte_track::STrack::STrack(const Rect<float>& rect, const float& score) :
     kalman_filter_(),

--- a/src/lapjv.cpp
+++ b/src/lapjv.cpp
@@ -1,5 +1,6 @@
 #include "ByteTrack/lapjv.h"
 
+#include <cstddef>
 #include <stdexcept>
 
 #define LAPJV_CPP_NEW(x, t, n) if ((x = (t *)malloc(sizeof(t) * (n))) == 0) { return -1; }

--- a/src/lapjv.cpp
+++ b/src/lapjv.cpp
@@ -1,6 +1,7 @@
 #include "ByteTrack/lapjv.h"
 
 #include <cstddef>
+#include <cstring>
 #include <stdexcept>
 
 #define LAPJV_CPP_NEW(x, t, n) if ((x = (t *)malloc(sizeof(t) * (n))) == 0) { return -1; }

--- a/src/lapjv.cpp
+++ b/src/lapjv.cpp
@@ -1,4 +1,6 @@
-#include <ByteTrack/lapjv.h>
+#include "ByteTrack/lapjv.h"
+
+#include <stdexcept>
 
 #define LAPJV_CPP_NEW(x, t, n) if ((x = (t *)malloc(sizeof(t) * (n))) == 0) { return -1; }
 #define LAPJV_CPP_FREE(x) if (x != 0) { free(x); x = 0; }

--- a/test/test_BYTETracker.cpp
+++ b/test/test_BYTETracker.cpp
@@ -1,11 +1,13 @@
-#include <ByteTrack/BYTETracker.h>
+#include "ByteTrack/BYTETracker.h"
 
-#include <gtest/gtest.h>
+#include "gtest/gtest.h"
 
-#include <boost/property_tree/ptree.hpp>
-#include <boost/property_tree/json_parser.hpp>
-#include <boost/foreach.hpp>
-#include <boost/optional.hpp>
+#include "boost/property_tree/ptree.hpp"
+#include "boost/property_tree/json_parser.hpp"
+#include "boost/foreach.hpp"
+#include "boost/optional.hpp"
+
+#include <cstddef>
 
 namespace
 {


### PR DESCRIPTION
As described in issue #6, there were some header includes missing.
I have added the includes where they were needed, and removed them from places where they were not.
For this, I have tried to stick to the [Google C++ Guidelines](https://google.github.io/styleguide/cppguide.html). 
If you prefer a different style, do let me know and I will adapt the changes in this PR.

I also took the liberty to fix a warning related to the usage of `LONG_MAX` for a float value, replacing it with `std::numeric_limits<float>::max()`.

With these changes, the library builds without errors or warning for my particular compiler settings.