### PR TITLE
Cmake fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,17 +21,18 @@ else()
   message(FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER} has no C++17 support. Please use a different C++ compiler.")
 endif()
 
-find_package(Eigen3 3.3.0 QUIET)
+set(EIGEN_VERSION 3.3)
+find_package(Eigen3 ${EIGEN_VERSION} QUIET)
 if(NOT EIGEN3_FOUND)
   set(BUILD_TESTING OFF CACHE INTERNAL "")
   FetchContent_Declare(eigen
     GIT_REPOSITORY  https://gitlab.com/libeigen/eigen.git
-    GIT_TAG         3.3
+    GIT_TAG         ${EIGEN_VERSION}
     GIT_SHALLOW     ON)
   FetchContent_MakeAvailable(eigen)
   unset(BUILD_TESTING CACHE)
   FetchContent_GetProperties(eigen BINARY_DIR Eigen3_DIR)
-  find_package(Eigen3 3.3.0 REQUIRED)
+  find_package(Eigen3 ${EIGEN_VERSION} REQUIRED)
 endif()
 
 add_library(${PROJECT_NAME} SHARED

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,8 +31,6 @@ if(NOT EIGEN3_FOUND)
     GIT_SHALLOW     ON)
   FetchContent_MakeAvailable(eigen)
   unset(BUILD_TESTING CACHE)
-  FetchContent_GetProperties(eigen BINARY_DIR Eigen3_DIR)
-  find_package(Eigen3 ${EIGEN_VERSION} REQUIRED)
 endif()
 
 add_library(${PROJECT_NAME} SHARED

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,20 +26,18 @@ if(NOT EIGEN3_FOUND)
   message(FATAL_ERROR "Eigen > 3.3.0 not found.")
 endif()
 
-include_directories(
-  ${PROJECT_SOURCE_DIR}/include
+add_library(${PROJECT_NAME} SHARED
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/BYTETracker.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/KalmanFilter.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/lapjv.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/Object.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/Rect.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/STrack.cpp
+  )
+target_include_directories(${PROJECT_NAME} PUBLIC
+  ${CMAKE_CURRENT_SOURCE_DIR}/include
   ${EIGEN3_INCLUDE_DIR}
   )
-
-add_library(${PROJECT_NAME} SHARED
-  ${PROJECT_SOURCE_DIR}/src/BYTETracker.cpp
-  ${PROJECT_SOURCE_DIR}/src/KalmanFilter.cpp
-  ${PROJECT_SOURCE_DIR}/src/lapjv.cpp
-  ${PROJECT_SOURCE_DIR}/src/Object.cpp
-  ${PROJECT_SOURCE_DIR}/src/Rect.cpp
-  ${PROJECT_SOURCE_DIR}/src/STrack.cpp
-  )
-
 target_link_libraries(${PROJECT_NAME}
   ${EIGEN3_LIBS}
   )
@@ -55,7 +53,7 @@ if(BUILD_BYTETRACK_TEST)
   endif()
 
   add_executable(${PROJECT_NAME}_test
-    ${PROJECT_SOURCE_DIR}/test/test_BYTETracker.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/test_BYTETracker.cpp
   )
 
   target_link_libraries(${PROJECT_NAME}_test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,11 +36,8 @@ add_library(${PROJECT_NAME} SHARED
   )
 target_include_directories(${PROJECT_NAME} PUBLIC
   ${CMAKE_CURRENT_SOURCE_DIR}/include
-  ${EIGEN3_INCLUDE_DIR}
   )
-target_link_libraries(${PROJECT_NAME}
-  ${EIGEN3_LIBS}
-  )
+target_link_libraries(${PROJECT_NAME} Eigen3::Eigen)
 
 # Build the tests if the 'BUILD_BYTETRACK_TEST' variable is set to 'ON'
 set(BUILD_BYTETRACK_TEST OFF CACHE BOOL "The flag whether to build the tests or not")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,15 @@ endif()
 
 find_package(Eigen3 3.3.0 QUIET)
 if(NOT EIGEN3_FOUND)
-  message(FATAL_ERROR "Eigen > 3.3.0 not found.")
+  set(BUILD_TESTING OFF CACHE INTERNAL "")
+  FetchContent_Declare(eigen
+    GIT_REPOSITORY  https://gitlab.com/libeigen/eigen.git
+    GIT_TAG         3.3
+    GIT_SHALLOW     ON)
+  FetchContent_MakeAvailable(eigen)
+  unset(BUILD_TESTING CACHE)
+  FetchContent_GetProperties(eigen BINARY_DIR Eigen3_DIR)
+  find_package(Eigen3 3.3.0 REQUIRED)
 endif()
 
 add_library(${PROJECT_NAME} SHARED


### PR DESCRIPTION
Thank you for merging the last PR! 
I was away on the weekend, so I apologize for the late response.

As promised, here is the PR addressing issues #8 and #9, making modifications to the CMake code.
With this PR, the configure step will 
 - Download Eigen according to the `EIGEN_VERSION` variable, here set to 3.3
 - Properly set the `INTERFACE_INCLUDE_DIRECTORIES` on the `bytetrack` target

This makes it significantly easier to use ByteTrack from other CMake projects (as is my use case).

## Side note
In the mean time, I have been making more drastic changes to the main code, since it looks like I will be using this library quite intensively.

Namely I have
 - Enforced a consistent style using `clang-format` and committed that configuration file
 - Refactored the main `ByteTrack::update` method for (what I think is) better readability
 - Removed any use of `new` and `delete` for the `lapjv` invocation and replaced it with `std::vector`
 - Removed the basically unused `Object` class, integrating it into the `STrack` class
 - Removed any use of `const int&` or other constant primitive references, as these have no benefit

as well as some other minor changes.\
None of those changes are in this PR, but if you are interested I could make additional PRs.